### PR TITLE
add chicago back to the bot

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -194,6 +194,7 @@ roles:
     - norcal
     - socal
     - canada
+    - chicago
     - dc
     - euro
     - japan


### PR DESCRIPTION
chicago not showing up on role list, but is a role (and the default stand-in role for midwest)